### PR TITLE
feat: add delete_document tool for removing documents from corpus

### DIFF
--- a/rag_agent/agent.py
+++ b/rag_agent/agent.py
@@ -1,0 +1,114 @@
+from google.adk.agents import Agent
+
+from .tools.add_data import add_data
+from .tools.create_corpus import create_corpus
+from .tools.delete_corpus import delete_corpus
+from .tools.delete_document import delete_document
+from .tools.get_corpus_info import get_corpus_info
+from .tools.list_corpora import list_corpora
+from .tools.rag_query import rag_query
+
+root_agent = Agent(
+    name="RagAgent",
+    model="gemini-2.5-flash",
+    description="Vertex AI RAG Agent",
+    tools=[
+        rag_query,
+        list_corpora,
+        create_corpus,
+        add_data,
+        get_corpus_info,
+        delete_corpus,
+        delete_document,
+    ],
+    instruction="""
+    # Vertex AI RAG Agent
+
+    You are a helpful RAG (Retrieval Augmented Generation) agent that can interact with Vertex AI's document corpora.
+    You can retrieve information from corpora, list available corpora, create new corpora, add new documents to corpora, 
+    get detailed information about specific corpora, delete specific documents from corpora, 
+    and delete entire corpora when they're no longer needed.
+    
+    ## Your Capabilities
+    
+    1. **Query Documents**: You can answer questions by retrieving relevant information from document corpora.
+    2. **List Corpora**: You can list all available document corpora to help users understand what data is available.
+    3. **Create Corpus**: You can create new document corpora for organizing information.
+    4. **Add New Data**: You can add new documents (Google Drive URLs, etc.) to existing corpora.
+    5. **Get Corpus Info**: You can provide detailed information about a specific corpus, including file metadata and statistics.
+    6. **Delete Document**: You can delete a specific document from a corpus when it's no longer needed.
+    7. **Delete Corpus**: You can delete an entire corpus and all its associated files when it's no longer needed.
+    
+    ## How to Approach User Requests
+    
+    When a user asks a question:
+    1. First, determine if they want to manage corpora (list/create/add data/get info/delete) or query existing information.
+    2. If they're asking a knowledge question, use the `rag_query` tool to search the corpus.
+    3. If they're asking about available corpora, use the `list_corpora` tool.
+    4. If they want to create a new corpus, use the `create_corpus` tool.
+    5. If they want to add data, ensure you know which corpus to add to, then use the `add_data` tool.
+    6. If they want information about a specific corpus, use the `get_corpus_info` tool.
+    7. If they want to delete a specific document, use the `delete_document` tool with confirmation.
+    8. If they want to delete an entire corpus, use the `delete_corpus` tool with confirmation.
+    
+    ## Using Tools
+    
+    You have seven specialized tools at your disposal:
+    
+    1. `rag_query`: Query a corpus to answer questions
+       - Parameters:
+         - corpus_name: The name of the corpus to query (required, but can be empty to use current corpus)
+         - query: The text question to ask
+    
+    2. `list_corpora`: List all available corpora
+       - When this tool is called, it returns the full resource names that should be used with other tools
+    
+    3. `create_corpus`: Create a new corpus
+       - Parameters:
+         - corpus_name: The name for the new corpus
+    
+    4. `add_data`: Add new data to a corpus
+       - Parameters:
+         - corpus_name: The name of the corpus to add data to (required, but can be empty to use current corpus)
+         - paths: List of Google Drive or GCS URLs
+    
+    5. `get_corpus_info`: Get detailed information about a specific corpus
+       - Parameters:
+         - corpus_name: The name of the corpus to get information about
+         
+    6. `delete_document`: Delete a specific document from a corpus
+       - Parameters:
+         - corpus_name: The name of the corpus containing the document
+         - document_id: The ID of the document to delete (can be obtained from get_corpus_info results)
+         - confirm: Boolean flag that must be set to True to confirm deletion
+         
+    7. `delete_corpus`: Delete an entire corpus and all its associated files
+       - Parameters:
+         - corpus_name: The name of the corpus to delete
+         - confirm: Boolean flag that must be set to True to confirm deletion
+    
+    ## INTERNAL: Technical Implementation Details
+    
+    This section is NOT user-facing information - don't repeat these details to users:
+    
+    - The system tracks a "current corpus" in the state. When a corpus is created or used, it becomes the current corpus.
+    - For rag_query and add_data, you can provide an empty string for corpus_name to use the current corpus.
+    - If no current corpus is set and an empty corpus_name is provided, the tools will prompt the user to specify one.
+    - Whenever possible, use the full resource name returned by the list_corpora tool when calling other tools.
+    - Using the full resource name instead of just the display name will ensure more reliable operation.
+    - Do not tell users to use full resource names in your responses - just use them internally in your tool calls.
+    
+    ## Communication Guidelines
+    
+    - Be clear and concise in your responses.
+    - If querying a corpus, explain which corpus you're using to answer the question.
+    - If managing corpora, explain what actions you've taken.
+    - When new data is added, confirm what was added and to which corpus.
+    - When corpus information is displayed, organize it clearly for the user.
+    - When deleting a document or corpus, always ask for confirmation before proceeding.
+    - If an error occurs, explain what went wrong and suggest next steps.
+    - When listing corpora, just provide the display names and basic information - don't tell users about resource names.
+    
+    Remember, your primary goal is to help users access and manage information through RAG capabilities.
+    """,
+)

--- a/rag_agent/tools/__init__.py
+++ b/rag_agent/tools/__init__.py
@@ -1,0 +1,29 @@
+"""
+RAG Tools package for interacting with Vertex AI RAG corpora.
+"""
+
+from .add_data import add_data
+from .create_corpus import create_corpus
+from .delete_corpus import delete_corpus
+from .delete_document import delete_document
+from .get_corpus_info import get_corpus_info
+from .list_corpora import list_corpora
+from .rag_query import rag_query
+from .utils import (
+    check_corpus_exists,
+    get_corpus_resource_name,
+    set_current_corpus,
+)
+
+__all__ = [
+    "add_data",
+    "create_corpus",
+    "list_corpora",
+    "rag_query",
+    "get_corpus_info",
+    "delete_corpus",
+    "delete_document",
+    "check_corpus_exists",
+    "get_corpus_resource_name",
+    "set_current_corpus",
+]

--- a/rag_agent/tools/delete_document.py
+++ b/rag_agent/tools/delete_document.py
@@ -1,0 +1,54 @@
+"""
+Tool for deleting a specific document from a Vertex AI RAG corpus.
+"""
+
+from google.adk.tools.tool_context import ToolContext
+from vertexai import rag
+
+from .utils import check_corpus_exists, get_corpus_resource_name
+
+def delete_document(
+    corpus_name: str,
+    document_id: str,
+    tool_context: ToolContext,
+) -> dict:
+    """
+    Delete a specific document from a Vertex AI RAG corpus.
+
+    Args:
+        corpus_name (str): The full resource name of the corpus containing the document.
+                          Preferably use the resource_name from list_corpora results.
+        document_id (str): The ID of the specific document/file to delete. This can be
+                          obtained from get_corpus_info results.
+        tool_context (ToolContext): The tool context
+
+    Returns:
+        dict: Status information about the deletion operation
+    """
+
+    if not check_corpus_exists(corpus_name, tool_context):
+        return {
+            "status": "error",
+            "message": f"Corpus '{corpus_name}' does not exist",
+            "corpus_name": corpus_name,
+            "document_id": document_id,
+        }
+
+    try:
+        corpus_resource_name = get_corpus_resource_name(corpus_name)
+        rag_file_path = f"{corpus_resource_name}/ragFiles/{document_id}"
+        rag.delete_file(rag_file_path)
+
+        return {
+            "status": "success",
+            "message": f"Successfully deleted document '{document_id}' from corpus '{corpus_name}'",
+            "corpus_name": corpus_name,
+            "document_id": document_id,
+        }
+    except Exception as e:
+        return {
+            "status": "error",
+            "message": f"Error deleting document: {str(e)}",
+            "corpus_name": corpus_name,
+            "document_id": document_id,
+        }


### PR DESCRIPTION
## 📝 Description

This PR adds the ability to delete specific documents from a RAG corpus without removing the entire corpus, providing more granular control over corpus content management.

## ✨ What's New

### New Tool: `delete_document`
- Delete individual documents from a corpus by document ID
- Maintains corpus integrity while removing specific files
- Includes proper error handling and validation

### Integration
- Added to agent's tool list
- Updated agent instructions to include document deletion capability
- Integrated into tools package exports

## 🔧 Changes Made

- **New file:** `rag_agent/tools/delete_document.py` - Core deletion functionality
- **Updated:** `rag_agent/agent.py` - Added tool to agent configuration
- **Updated:** `rag_agent/tools/__init__.py` - Exported delete_document function

## 📋 Features

- ✅ Delete specific documents by ID
- ✅ Validate corpus existence before deletion
- ✅ Clear error messages for failed operations
- ✅ Success confirmation with corpus and document details

## 🎯 Use Cases

- Remove outdated documents from corpus
- Clean up test documents
- Manage corpus content without full deletion
- Fine-grained corpus maintenance

## ✅ Checklist

- [x] Code follows project conventions
- [x] Tool properly integrated into agent
- [x] Error handling implemented
- [x] Function documented with docstrings
- [x] Follows Conventional Commits standard

## 🔗 Related

Part of corpus management feature set alongside:
- `delete_corpus` - Delete entire corpus
- `get_corpus_info` - View corpus details including document IDs